### PR TITLE
add initial logic to episode fetch

### DIFF
--- a/music-podcast/src/episode/endpoint/get-episodes-endpoint.ts
+++ b/music-podcast/src/episode/endpoint/get-episodes-endpoint.ts
@@ -1,0 +1,8 @@
+import { EpisodeResult } from "../mapper";
+
+export const getEpisodesEndpoint = async (id: number) => {
+	return await fetch(`https://itunes.apple.com/lookup?id=${id}&media=podcast&entity=podcastEpisode`, {
+			method: 'GET',
+			headers: { 'Content-Type': 'application/json' }
+		}).then((res: Response) => res.json()) as Promise<EpisodeResult>
+	}

--- a/music-podcast/src/episode/mapper/index.ts
+++ b/music-podcast/src/episode/mapper/index.ts
@@ -1,0 +1,1 @@
+export * from "./mapEpisodeFromItunes";

--- a/music-podcast/src/episode/mapper/mapEpisodeFromItunes.ts
+++ b/music-podcast/src/episode/mapper/mapEpisodeFromItunes.ts
@@ -1,0 +1,68 @@
+import { DetailedItunesPodcast } from "../../podcast/mapper/mapDetailedPodcastFromItunes";
+import { Episode } from "../model";
+
+interface EpisodeGenre {
+  name: string;
+  id: string;
+}
+
+export interface ItunesEpisode extends Partial<DetailedItunesPodcast>{
+  country: string;
+  previewUrl?: string;
+  artistIds?: number[];
+  genres: EpisodeGenre[] | string[];
+  episodeGuid?: string;
+  description?: string;
+  shortDescription?: string;
+  trackId: number;
+  trackName: string;
+  collectionId: number;
+  collectionName: string;
+  feedUrl: string;
+  closedCaptioning?: string;
+  releaseDate: Date;
+  contentAdvisoryRating: string;
+  trackViewUrl: string;
+  artworkUrl160?: string;
+  episodeFileExtension?: string;
+  episodeContentType?: string;
+  collectionViewUrl: string;
+  trackTimeMillis: number;
+  episodeUrl?: string;
+  artworkUrl600: string;
+  artworkUrl60: string;
+  artistViewUrl: string;
+  kind: string;
+}
+
+export interface EpisodeResult {
+	resultCount: number;
+	results: ItunesEpisode[];
+}
+
+type Mapper<BackendType, MappedType> = (input: BackendType) => MappedType;
+
+export const mapEpisode: Mapper<ItunesEpisode, Episode> = input => {
+	return {
+		id: input.trackId,
+		name: input.trackName,
+		description: input.description,
+		releaseDate: input.releaseDate,
+		collectionId: input.collectionId,
+		trackTimeMillis: input.trackTimeMillis,
+		episodeUrl: input.episodeUrl,
+		collectionName: input.collectionName
+	}
+}
+
+export const mapEpisodes = (episodes: ItunesEpisode[]): Episode[] => 
+	episodes.map(mapEpisode).map((episode, index) => {
+	return {
+		...episode,
+		index,
+	}
+	})
+
+export const mapEpisodesResults: Mapper<EpisodeResult, Episode[]> = input => {
+	return mapEpisodes(input.results)
+}

--- a/music-podcast/src/episode/model/episode.model.ts
+++ b/music-podcast/src/episode/model/episode.model.ts
@@ -1,0 +1,10 @@
+export interface Episode {
+	id: number;
+	collectionId: number;
+	name: string;
+	description?: string;
+	collectionName: string;
+	releaseDate: Date;
+	episodeUrl?: string;
+	trackTimeMillis: number;
+}

--- a/music-podcast/src/episode/model/index.ts
+++ b/music-podcast/src/episode/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./episode.model";

--- a/music-podcast/src/episode/service/get-episodes.ts
+++ b/music-podcast/src/episode/service/get-episodes.ts
@@ -1,0 +1,17 @@
+import { getEpisodesEndpoint } from "../endpoint/get-episodes-endpoint";
+import { mapEpisodesResults } from "../mapper";
+import { Episode } from "../model";
+
+type GetEpisodesFromAPI = (podcastId: number) => Promise<Episode[]>;
+
+export const getEpisodesFromItunes: GetEpisodesFromAPI = async (podcastId: number) => {
+	try {
+		return await getEpisodesEndpoint(podcastId).then((data) => {
+			return mapEpisodesResults(data);
+		})
+	}
+	catch (err) {
+		console.error(err);
+		throw new Error("Error at retrieving the podcasts");
+	}
+}

--- a/music-podcast/src/episode/service/index.ts
+++ b/music-podcast/src/episode/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./get-episodes";

--- a/music-podcast/src/episode/use-case/get-episodes.ts
+++ b/music-podcast/src/episode/use-case/get-episodes.ts
@@ -1,0 +1,5 @@
+import { getEpisodesFromItunes } from "../service";
+
+export const getAllEpisodes = (podcastId: number) => {
+	return getEpisodesFromItunes(podcastId);
+};

--- a/music-podcast/src/episode/use-case/index.ts
+++ b/music-podcast/src/episode/use-case/index.ts
@@ -1,0 +1,1 @@
+export * from "./get-episodes";

--- a/music-podcast/src/podcast/mapper/mapDetailedPodcastFromItunes.ts
+++ b/music-podcast/src/podcast/mapper/mapDetailedPodcastFromItunes.ts
@@ -1,0 +1,37 @@
+export interface DetailedItunesPodcast {
+	resultCount: number;
+	results: [{
+		wrapperType: string;
+		kind: string;
+		artistId: number;
+		collectionId: number;
+		trackId: number;
+		artistName: string;
+		collectionName: string;
+		trackName: string;
+		collectionCensoredName: string;
+		trackCensoredName: string;
+		artistViewUrl: string;
+		collectionViewUrl: string;
+		feedUrl: string;
+		trackViewUrl: string;
+		artworkUrl30: string;
+		artworkUrl60: string;
+		artworkUrl100: string;
+		collectionPrice: number;
+		trackPrice: number;
+		collectionHdPrice: number;
+		releaseDate: Date;
+		collectionExplicitness: string;
+		trackExplicitness: string;
+		trackCount: number;
+		trackTimeMillis: number;
+		country: string;
+		currency: string;
+		primaryGenreName: string;
+		contentAdvisoryRating: string;
+		artworkUrl600: string;
+		genreIds: string[];
+		genres: string[];
+	}]
+}

--- a/music-podcast/src/podcast/mapper/mapPodcastFromItunes.ts
+++ b/music-podcast/src/podcast/mapper/mapPodcastFromItunes.ts
@@ -109,3 +109,4 @@ export const mapPodcastsFromItunes: Mapper<ItunesPodcast, RawPodcast> = input =>
 		podcast: mapPodcasts(input.feed.entry)
 	};
 };
+


### PR DESCRIPTION
se añade el fetch a los episodios de un podcast
se añaden los models y mappers necesarios
se crea el servicio para llamar a los episodios

Es necesario pasar un id de podcast para poder acceder a sus episodios